### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server that provides access to prediction market data through the PolyMarket API. This server implements a standardized interface for retrieving market information, prices, and historical data from prediction markets.
 
+<a href="https://glama.ai/mcp/servers/c255m147fd">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/c255m147fd/badge" alt="PolyMarket Server MCP server" />
+</a>
+
 ## Features
 
 - Real-time prediction market data with current prices and probabilities
@@ -39,7 +43,7 @@ npx -y @smithery/cli install polymarket_mcp --client claude
             ],
             "env": {
                 "KEY": "<insert poly market api key>",
-                "FUNDER": "<insert polymarket wallet address"
+                "FUNDER": "<insert polymarket wallet address>"
             }
         }
     }


### PR DESCRIPTION
This PR adds a badge for the [PolyMarket MCP Server](https://glama.ai/mcp/servers/c255m147fd) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/c255m147fd">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/c255m147fd/badge" alt="PolyMarket Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.